### PR TITLE
カードをSNSにシェアする際に、サイト名を石川県向けのものに変更

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -257,9 +257,9 @@ export default Vue.extend({
         'https://twitter.com/intent/tweet?text=' +
         this.title +
         ' / ' +
-        this.$t('東京都') +
+        this.$t('石川県') +
         this.$t('新型コロナウイルス感染症') +
-        this.$t('対策サイト') +
+        this.$t('対策サイト(非公式)') +
         '&url=' +
         this.permalink(true) +
         '&' +

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -163,10 +163,10 @@ export default {
           content:
             this.title +
             ' | ' +
-            this.$t('東京都') +
+            this.$t('石川県') +
             ' ' +
             this.$t('新型コロナウイルス感染症') +
-            this.$t('対策サイト')
+            this.$t('対策サイト(非公式)')
         },
         {
           hid: 'description',


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close https://github.com/Retsuki/covid19-ishikawa/issues/5

## 📝 関連する issue / Related Issues
- https://github.com/Retsuki/covid19-ishikawa/issues/5

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- カードのリンクをSNS (TwitterとFacebook、LINE) でシェアするときに、サイト名を`石川県 新型コロナウイルス感染症対策サイト(非公式)`となるように変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

Twitterでの見え方
<img width="713" alt="スクリーンショット 2020-04-04 18 19 18" src="https://user-images.githubusercontent.com/7448569/78423360-d5adbf00-76a0-11ea-9031-722db8eba830.png">

Facebookでの見え方
<img width="543" alt="スクリーンショット 2020-04-04 18 20 08" src="https://user-images.githubusercontent.com/7448569/78423389-f2e28d80-76a0-11ea-8be8-cfaab0c46efd.png">

LINEでの見え方
<img width="431" alt="スクリーンショット 2020-04-04 18 20 47" src="https://user-images.githubusercontent.com/7448569/78423400-068df400-76a1-11ea-9cb0-2ec127e1801f.png">

## 検証方法
FacebookとLINEのサイト名修正はローカル開発環境での変更確認が困難なため、以下の手法を用いて、一時的にローカル開発環境をインターネットに公開して確認を行ってます。

1. ポート8080でローカル開発環境を起動

```
$ HOST=0.0.0.0 PORT=8080 npm run dev
```

2. ngrokでローカル開発環境を外部公開

参考: [ngrokを使用してローカル環境を外部に公開する - Qiita](
https://qiita.com/kitaro0729/items/44214f9f81d3ebda58bd)

```
$ ngrok http 8080
```

3. ngrokでアクセス用に発行されたURLをOGP確認ツールに入力し、内容を確認

[OGP確認：facebook、twitter、LINE、はてなブログのシェア時の画像・設定を表示 | ラッコツールズ🔧](
https://rakko.tools/tools/9/)

